### PR TITLE
107: investigate why navigation in iOS takes too long; remove redunda…

### DIFF
--- a/src/scenes/App.ios.js
+++ b/src/scenes/App.ios.js
@@ -9,17 +9,17 @@ import {
 import React, {Component, PropTypes} from 'react';
 import Navigation from './Navigation';
 import Navigate from '../utils/Navigate';
-import { Toolbar } from '../components';
+import {Toolbar} from '../components';
 import Drawer from 'react-native-drawer'
 import {Provider} from 'react-redux';
 import store from '../store';
 import styles from '../styles';
 import {connect} from 'react-redux';
 
-import { fetchRegionFromStorage } from '../actions/region';
-import { fetchDirectionFromStorage } from '../actions/direction';
-import { fetchLanguageFromStorage } from '../actions/language';
-import { fetchCountryFromStorage } from '../actions/country';
+import {fetchRegionFromStorage} from '../actions/region';
+import {fetchDirectionFromStorage} from '../actions/direction';
+import {fetchLanguageFromStorage} from '../actions/language';
+import {fetchCountryFromStorage} from '../actions/country';
 
 
 export class App extends Component {
@@ -39,12 +39,12 @@ export class App extends Component {
     }
 
     async componentDidMount() {
-      const {dispatch} = this.props;
+        const {dispatch} = this.props;
 
-      await dispatch(fetchRegionFromStorage());
-      await dispatch(fetchDirectionFromStorage());
-      await dispatch(fetchLanguageFromStorage());
-      await dispatch(fetchCountryFromStorage());
+        await dispatch(fetchRegionFromStorage());
+        await dispatch(fetchDirectionFromStorage());
+        await dispatch(fetchLanguageFromStorage());
+        await dispatch(fetchCountryFromStorage());
     }
 
     getChildContext = () => {
@@ -68,24 +68,24 @@ export class App extends Component {
     };
 
     render() {
-        const { drawer, navigator } = this.state;
+        const {drawer, navigator} = this.state;
         let sceneConfig = {...Navigator.SceneConfigs.FloatFromBottom};
 
         // Removing the pop gesture
         delete sceneConfig.gestures.pop;
 
         return (
-          <Drawer
-              ref={(drawer) =>{
+            <Drawer
+                ref={(drawer) =>{
                   this.drawer = drawer;
               }}
-              type="overlay"
-              acceptTap={true}
-              content={
+                type="overlay"
+                acceptTap={true}
+                content={
                   <Navigation />
               }
-              tapToClose={true}
-              styles={{
+                tapToClose={true}
+                styles={{
               main: {
                   paddingLeft: 3,
                   backgroundColor: '#F5F5F5'
@@ -95,31 +95,31 @@ export class App extends Component {
                   shadowOpacity: 0.8,
                   shadowRadius: 3
               }}}
-              onOpen={() => {
+                onOpen={() => {
                   this.setState({drawerOpen: true})
               }}
-              onClose={() => {
+                onClose={() => {
                   this.setState({drawerOpen: false})
               }}
-              captureGestures={false}
-              tweenDuration={100}
-              panThreshold={0.08}
-              openDrawerOffset={0.2}
-              closedDrawerOffset={() => -3}
-              panOpenMask={0.02}
-          >
-              <StatusBar
-                  barStyle={'light-content'}
-              />
-              {!drawer &&
-              <Navigator
-                  configureScene={() => {
+                captureGestures={false}
+                tweenDuration={100}
+                panThreshold={0.08}
+                openDrawerOffset={0.2}
+                closedDrawerOffset={() => -3}
+                panOpenMask={0.02}
+            >
+                <StatusBar
+                    barStyle={'light-content'}
+                />
+                {!drawer &&
+                <Navigator
+                    configureScene={() => {
                       return sceneConfig;
                   }}
-                  initialRoute={Navigate.getInitialRoute()}
-                  navigationBar={<Toolbar onIconPress={this.openDrawer} />}
-                  ref={(navigator) => { !this.state.navigator ? this.setNavigator(navigator) : null; }}
-                  renderScene={(route) => {
+                    initialRoute={Navigate.getInitialRoute()}
+                    navigationBar={<Toolbar onIconPress={this.openDrawer} />}
+                    ref={(navigator) => { !this.state.navigator ? this.setNavigator(navigator) : null; }}
+                    renderScene={(route) => {
                       if (this.state.navigator && route.component) {
 
                           let instance =
@@ -131,17 +131,18 @@ export class App extends Component {
 
                           return (
                               <View
-                                  showsVerticalScrollIndicator={true}
-                                  style={[styles.scene,!(this.state && !this.state.drawerOpen) ? {width: 0, height: 0} : {}]}
+                                pointerEvents={this.state.drawerOpen ? 'none' : 'auto'}
+                                showsVerticalScrollIndicator={true}
+                                style={styles.scene}
                               >
                               {instance}
                               </View>
                           );
                       }
                   }}
-              />
-              }
-          </Drawer>
+                />
+                }
+            </Drawer>
         )
     }
 }

--- a/src/scenes/GeneralInformation.js
+++ b/src/scenes/GeneralInformation.js
@@ -47,7 +47,6 @@ export class GeneralInformation extends Component {
         const { navigator } = this.context;
 
         if(!region) {
-          console.log("Store?", store.getState())
           navigator.to('countryChoice');
           return;
         }

--- a/src/scenes/Initial.js
+++ b/src/scenes/Initial.js
@@ -23,9 +23,6 @@ import { fetchCountryFromStorage } from '../actions/country';
     await dispatch(fetchLanguageFromStorage());
     await dispatch(fetchCountryFromStorage());
 
-
-    console.log(store.getState())
-
     if(!(r||false)) {
       this.context.navigator.to('countryChoice');
     } else {

--- a/src/scenes/Navigation.js
+++ b/src/scenes/Navigation.js
@@ -26,8 +26,6 @@ class Navigation extends Component {
 
     _getImportantInformation() {
       const region = this.props.region;
-      console.log(region);
-
       if(!region || !region.important_information) {
         return <View />;
       }

--- a/src/scenes/ServiceList.js
+++ b/src/scenes/ServiceList.js
@@ -90,7 +90,6 @@ export default class ServiceList extends Component {
         }
         locations.push(region);
         let lastSync = await AsyncStorage.getItem('lastServicesSync');
-        console.log(lastSync);
         this.setState({
             dataSource: this.state.dataSource.cloneWithRows(services),
             loaded: true,

--- a/src/scenes/Skeleton.js
+++ b/src/scenes/Skeleton.js
@@ -13,45 +13,43 @@ import {Provider} from 'react-redux';
 
 
 /**
-This class is the skeleton of the app.
+ This class is the skeleton of the app.
 
-This was removed from the index.*.js because of loading the language on start up and showing up
-welcome screen.
+ This was removed from the index.*.js because of loading the language on start up and showing up
+ welcome screen.
 
-*/
+ */
 class Skeleton extends Component {
     constructor(props) {
         super(props);
 
         this.state = {
-          firstLoad: true
+            firstLoad: true
         }
     }
 
     componentWillMount() {
         this.languagePromise = this.checkLanguageSelected();
-        console.log(store.getState());
-
     }
 
     componentDidMount() {
-      AppState.addEventListener('change', this._handleAppStateChange);
+        AppState.addEventListener('change', this._handleAppStateChange);
     }
 
     componentWillUnmount() {
-      AppState.removeEventListener('change', this._handleAppStateChange);
+        AppState.removeEventListener('change', this._handleAppStateChange);
     }
 
     _handleAppStateChange() {
-      console.log(arguments);
+        // console.log(arguments);
     }
 
     async checkLanguageSelected() {
         let code = (I18n.currentLocale() || 'en').split('-')[0];
-        if(!I18n.translations.hasOwnProperty(code)) {
-          // This means we don't have a translation for it
-          // So fallback to English
-          code = 'en';
+        if (!I18n.translations.hasOwnProperty(code)) {
+            // This means we don't have a translation for it
+            // So fallback to English
+            code = 'en';
         }
 
         // Instead of having the app handling the language selection we should
@@ -63,17 +61,17 @@ class Skeleton extends Component {
     }
 
     render() {
-        if(this.state.firstLoad) {
-          return (
-              <Welcome firstLoad={this.state.firstLoad} finished={()=> {
+        if (this.state.firstLoad) {
+            return (
+                <Welcome firstLoad={this.state.firstLoad} finished={()=> {
                 AsyncStorage.setItem('firstLoad','false');
                 this.setState({firstLoad: false});
-              } } />
-          );
+                } }/>
+            );
         } else {
-          return (
-              <App />
-          );
+            return (
+                <App />
+            );
         }
     }
 }

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -7,8 +7,6 @@ export default class ApiClient {
         this.navigator = context.navigator;
         this.apiRoot = api_root;
         this.language = props.language || 'en';
-
-        console.log("API Client Constructor", this);
     }
 
     async fetch(relativeUrl, raise_exception=false) {

--- a/src/utils/DrawerCommons.js
+++ b/src/utils/DrawerCommons.js
@@ -63,7 +63,6 @@ export default class DrawerCommons {
     changeScene = (path, name, props={}) => {
         const { drawer, navigator } = this.component.context;
         const { dispatch } = this.component.props;
-
         navigator.to(path, name, props);
         dispatch({type: 'CHANGE_ROUTE', payload: path});
         if (Platform.OS === 'ios'){

--- a/src/utils/Navigate.js
+++ b/src/utils/Navigate.js
@@ -87,7 +87,7 @@ export default class Navigate {
 			if (!this.isChild) {
 				route = Navigate.getInitialRoute();
 				this.currentRoute = route;
-				this.navigator.replace(route);
+				this.navigator.pop();
 				return true;
 			} else {
 				this.back();
@@ -177,9 +177,7 @@ export default class Navigate {
 					this.previousRoute = this.currentRoute;
 				}
 				this.currentRoute = route;
-
-				// RR: Changed push to replace because it caused weird behavior in iOS
-				this.navigator.replace(route);
+				this.navigator.push(route);
 				this.store.dispatch({type: 'CHANGE_ROUTE', payload: path});
 			}
 		}


### PR DESCRIPTION
…nt console logs; change navigation method back to push/pop; block main View actions when drawer is open
@reyrodrigues I've reverted navigate.replace back to push/pop - it was the reason why the app was running so slow few weeks ago. I'm not sure if there is a way to make navigate.replace as fast as push/pop. Can we please discuss today on Skype what kind of issues we have on iOS that we should use .replace?
also, some of console.logs were causing freezes up to 10 seconds long (on iOS only), so I've removed them. I hope I didn't break anything from your work ;)

https://refugeeinfo.atlassian.net/browse/RID-107