### PR TITLE
Disable map animations on iOS - probably fixes bug with corrupted mar…

### DIFF
--- a/src/scenes/ServiceMap.js
+++ b/src/scenes/ServiceMap.js
@@ -94,11 +94,6 @@ class ServiceMap extends Component {
         this.serviceCommons = new ServiceCommons();
     }
 
-    componentWillUpdate() {
-        // animations on Android causes markers to stop rendering
-        Platform.OS === 'ios' && LayoutAnimation.easeInEaseOut();
-    }
-
     componentDidMount() {
         const {region, searchCriteria, serviceTypes} = this.props;
         let currentEnvelope = ServiceMap.getInitialRegion(region);


### PR DESCRIPTION
…kers
need more testing. I was zooming in and out map for just 5 minutes, but it seems it got fixed.