### PR TITLE
Adding pseudo token by device

### DIFF
--- a/src/data/Presence.js
+++ b/src/data/Presence.js
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import { Component } from 'react';
 import {
     AsyncStorage,
     Platform
@@ -8,6 +8,29 @@ import store from '../store';
 let DeviceInfo = require('react-native-device-info');
 
 export default class Presence extends Component {
+    static createUUID() {
+        // http://www.ietf.org/rfc/rfc4122.txt
+        var s = [];
+        var hexDigits = "0123456789abcdef";
+        for (var i = 0; i < 36; i++) {
+            s[i] = hexDigits.substr(Math.floor(Math.random() * 0x10), 1);
+        }
+        s[14] = "4";  // bits 12-15 of the time_hi_and_version field to 0010
+        s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1);  // bits 6-7 of the clock_seq_hi_and_reserved to 01
+        s[8] = s[13] = s[18] = s[23] = "-";
+
+        var uuid = s.join("");
+        return uuid;
+    }
+
+    static async getDeviceToken() {
+        let token = await AsyncStorage.getItem('deviceToken');
+        if(!token) {
+            token = Presence.createUUID();
+            await AsyncStorage.setItem('deviceToken', token);
+        }
+        return token;
+    }
 
     static async getToken() {
         return await AsyncStorage.getItem('notificationToken');
@@ -53,13 +76,14 @@ export default class Presence extends Component {
             os: Platform.OS
         };
         token.path = navigation;
+        token.deviceToken = await Presence.getDeviceToken();
 
         try {
             let deviceId = DeviceInfo.getUniqueID();
             if (deviceId) {
                 token.deviceId = deviceId;
             }
-        } catch(e) {
+        } catch (e) {
 
         }
         token = JSON.stringify(token);

--- a/src/scenes/MicroApp.js
+++ b/src/scenes/MicroApp.js
@@ -14,6 +14,7 @@ import Share from 'react-native-share';
 import { WEB_PATH } from '../constants';
 import ApiClient from '../utils/ApiClient';
 import { Actions } from 'react-native-router-flux';
+import {Presence} from '../data';
 let DeviceInfo = require('react-native-device-info');
 
 
@@ -80,7 +81,7 @@ export class MicroApp extends Component {
     webViewReady() {
         let isTranslucent = isStatusBarTranslucent();
         let platform = Platform.OS;
-        let deviceId = DeviceInfo.getUniqueID();
+        let deviceId = Presence.getDeviceToken();
         let {region, language} = this.props;
 
         if (this.webView) {


### PR DESCRIPTION
This token should persist in the storage while the app is installed. This way we can correlate what is sent to the micro apps to what we have in the database without sharing device ids or notification tokens.